### PR TITLE
fix: anilist mappings route, cache key typo, missing awaits, and type fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Manvith911/kenjitsu.git"
+    "url": "git+https://github.com/middlegear/kenjitsu.git"
   },
   "keywords": [
     "anime",
@@ -38,9 +38,9 @@
   "author": "middlegear",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Manvith911/kenjitsu/issues"
+    "url": "https://github.com/middlegear/kenjitsu/issues"
   },
-  "homepage": "https://github.com/Manvith911/kenjitsu#readme",
+  "homepage": "https://github.com/middlegear/kenjitsu#readme",
   "devDependencies": {
     "@semantic-release/github": "^12.0.9",
     "@semantic-release/npm": "^13.1.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/middlegear/kenjitsu.git"
+    "url": "git+https://github.com/Manvith911/kenjitsu.git"
   },
   "keywords": [
     "anime",
@@ -38,9 +38,9 @@
   "author": "middlegear",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/middlegear/kenjitsu/issues"
+    "url": "https://github.com/Manvith911/kenjitsu/issues"
   },
-  "homepage": "https://github.com/middlegear/kenjitsu#readme",
+  "homepage": "https://github.com/Manvith911/kenjitsu#readme",
   "devDependencies": {
     "@semantic-release/github": "^12.0.9",
     "@semantic-release/npm": "^13.1.5",

--- a/src/routes/anime/anibd.ts
+++ b/src/routes/anime/anibd.ts
@@ -13,7 +13,7 @@ export default async function AniBDRoutes(fastify: FastifyInstance) {
     const { q } = request.query;
     if (!q) return reply.status(400).send({ error: "Missing required query param: 'q'" });
     if (q.length > 1000) return reply.status(400).send({ error: 'Query string too long' });
-    const cacheKey = `anibd -search-${q}`;
+    const cacheKey = `anibd-search-${q}`;
     const cachedData = await redisGetCache(cacheKey);
     if (cachedData) return reply.status(200).send(cachedData);
     try {
@@ -133,7 +133,7 @@ export default async function AniBDRoutes(fastify: FastifyInstance) {
           return reply.status(result.status as number).send({ error: result.error });
         }
         if (result.data && Array.isArray(result.data.sources) && result.data.sources.length > 0) {
-          redisSetCache(cacheKey, result, 12);
+          await redisSetCache(cacheKey, result, 12);
         }
         return reply.status(200).send(result);
       } catch (error) {

--- a/src/routes/anime/animeheaven.ts
+++ b/src/routes/anime/animeheaven.ts
@@ -111,7 +111,7 @@ export default async function AnimeHeavenRoutes(fastify: FastifyInstance) {
           return reply.status(result.status as number).send({ error: result.error });
         }
         if (result.data && Array.isArray(result.data.sources) && result.data.sources.length > 0) {
-          redisSetCache(cacheKey, result, 2);
+          await redisSetCache(cacheKey, result, 2);
         }
         return reply.status(200).send(result);
       } catch (error) {

--- a/src/routes/anime/anizone.ts
+++ b/src/routes/anime/anizone.ts
@@ -140,7 +140,7 @@ export default async function AnizoneRoutes(fastify: FastifyInstance) {
           return reply.status(result.status as number).send({ error: result.error });
         }
         if (result.data && Array.isArray(result.data.sources) && result.data.sources.length > 0) {
-          redisSetCache(cacheKey, result, 12);
+          await redisSetCache(cacheKey, result, 12);
         }
         return reply.status(200).send(result);
       } catch (error) {

--- a/src/routes/meta/anilist.ts
+++ b/src/routes/meta/anilist.ts
@@ -361,7 +361,7 @@ export default async function AnilistRoutes(fastify: FastifyInstance) {
     },
   );
   fastify.get(
-    '/anime/:id/mappings',
+    '/anime/mappings/:id',
 
     async (request: FastifyRequest<{ Querystring: FastifyQuery; Params: FastifyParams }>, reply: FastifyReply) => {
       reply.header('Cache-Control', `public, s-maxage=${24 * 60 * 60}, stale-while-revalidate=300`);

--- a/src/routes/torrent/nyaa.ts
+++ b/src/routes/torrent/nyaa.ts
@@ -49,7 +49,6 @@ export default async function NyaaRoutes(fastify: FastifyInstance) {
 
       const id = request.params.id;
       if (!id) return reply.status(400).send({ error: "Missing 'id' parameter" });
-      const episodeNumber = request.params.episode;
       const cacheKey = `nyaa-infohash-${id}`;
       const cachedData = await redisGetCache(cacheKey);
       if (cachedData) return reply.status(200).send(cachedData);

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -40,4 +40,4 @@ export const IAnimeCategoryArr = ['TV', 'MOVIE', 'SPECIALS', 'OVA', 'ONA'] as co
 export const IAnimeSeasonsArr = ['WINTER', 'SPRING', 'SUMMER', 'FALL'] as const;
 
 
-export const allowedAnimeProviders = ['anikoto', , 'anizone', , 'anidb', 'anibd', 'animeheaven', 'kitsu'];
+export const allowedAnimeProviders = ['anikoto', 'anizone', 'anidb', 'anibd', 'animeheaven', 'kitsu'];

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,7 +6,7 @@ export interface FastifyParams {
   genre?: string;
   country?: string;
   season?: string;
-  episode?: number;
+  episode?: string;
   year?: string;
   status?: string;
   category?: string;


### PR DESCRIPTION
### Summary
 
This PR fixes several issues across the codebase: a broken anilist mappings endpoint, a cache key typo, missing `await` calls on Redis operations, dead code, and an incorrect type definition.
 
### Changes
 
**1. Fix anilist mappings route path** (`src/routes/meta/anilist.ts`)
- Route was defined as `/anime/:id/mappings`, which didn't match the expected URL `/api/anilist/anime/mappings/:id`
- Changed to `/anime/mappings/:id` so the endpoint works correctly
 
**2. Clean up `allowedAnimeProviders` array** (`src/utils/types.ts`)
- Removed extra commas creating `undefined` holes in the array: `['anikoto', , 'anizone', , ...]` → `['anikoto', 'anizone', ...]`
 
**3. Fix cache key typo** (`src/routes/anime/anibd.ts`)
- Search cache key had an extra space: `` `anibd -search-${q}` `` → `` `anibd-search-${q}` ``
 
**4. Add missing `await` on `redisSetCache`** (`src/routes/anime/anizone.ts`, `src/routes/anime/animeheaven.ts`, `src/routes/anime/anibd.ts`)
- Three source endpoints were not awaiting `redisSetCache()`, which could cause unhandled promise rejections if Redis fails
 
**5. Remove dead code** (`src/routes/torrent/nyaa.ts`)
- Removed unused `episodeNumber` variable that referenced a non-existent route param
 
**6. Fix `FastifyParams.episode` type** (`src/utils/types.ts`)
- Changed `episode?: number` to `episode?: string` since URL params are always strings at runtime
 
### Testing
 
All changes are minimal, correctness-only fixes with no behavioral changes to working endpoints.
